### PR TITLE
Ajout du .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Fichier contenant des informations confidentielles
 .env
+
+# Fichiers générés par les dépendances et Jekyll
 _site/
 .sass-cache/
 .jekyll-cache/
@@ -7,3 +9,14 @@ _site/
 /vendor
 .idea/
 .DS_Store
+
+# Fichiers générés par VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+.history/
+*.vsix
+.vs/


### PR DESCRIPTION
Le fichier '.gitignore' contient une liste de fichiers et de répertoires qui doivent être ignorés par Git. 
Il est utilisé pour empêcher certains fichiers d'être suivis par Git et inclus dans le repository.
Il contient des règles pour ignorer les fichiers temporaires et les fichiers générés par le système de compilation.